### PR TITLE
Update the test / Use container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
   - '0.10'

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "ava": "0.0.4",
+    "buffer-equal": "0.0.1",
     "is-jpg": "^1.0.0",
     "vinyl-file": "^1.1.0"
   }

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var bufferEqual = require('buffer-equal');
 var isJpg = require('is-jpg');
 var path = require('path');
 var read = require('vinyl-file').read;
@@ -33,6 +34,23 @@ test('strip path level using the `strip` option', function (t) {
 		stream.on('data', function (file) {
 			t.assert(file.path === 'test.jpg');
 			t.assert(isJpg(file.contents));
+		});
+
+		stream.end(file);
+	});
+});
+
+test('skip decompressing a non-TAR.GZ file', function (t) {
+	t.plan(2);
+
+	read(__filename, function (err, file) {
+		t.assert(!err, err);
+
+		var stream = targz();
+		var contents = file.contents;
+
+		stream.on('data', function (data) {
+			t.assert(bufferEqual(data.contents, contents));
 		});
 
 		stream.end(file);


### PR DESCRIPTION
* I added a test case when decompress-targz takes non-TAR.GZ data.
* I added `sudo: false` to .travis.yml to [use container-based infrastructure on Travis CI](http://docs.travis-ci.com/user/workers/container-based-infrastructure/).

------------------------------------

After merging this, please release a new version. ([deps have been updated](https://github.com/kevva/decompress-targz/commit/0f7050a7b5ac4874cbe49fd61cb45f4850975332))