### PR TITLE
catch unzip error

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,8 @@ module.exports = function (opts) {
 
 		extract.on('finish', cb);
 		extract.on('error', cb);
+		
+		unzip.on('error', cb);
 		unzip.end(file.contents);
 		unzip.pipe(extract);
 	});


### PR DESCRIPTION
When something like `zlib.error: Error -3 while decompressing: incorrect header check` happens.
